### PR TITLE
[YUNIKORN-2504] Support canonical labels for queue/applicationId in scheduler

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -90,8 +90,8 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 			Name:      placeholderName,
 			Namespace: app.tags[constants.AppTagNamespace],
 			Labels: utils.MergeMaps(taskGroup.Labels, map[string]string{
-				constants.LabelApplicationID: app.GetApplicationID(),
-				constants.LabelQueueName:     app.GetQueue(),
+				constants.CanonicalLabelApplicationID: app.GetApplicationID(),
+				constants.CanonicalLabelQueueName:     app.GetQueue(),
 			}),
 			Annotations:     annotations,
 			OwnerReferences: ownerRefs,

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -125,10 +125,10 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, holder.pod.Name, "ph-name")
 	assert.Equal(t, holder.pod.Namespace, namespace)
 	assert.DeepEqual(t, holder.pod.Labels, map[string]string{
-		constants.LabelApplicationID: appID,
-		constants.LabelQueueName:     queue,
-		"labelKey0":                  "labelKeyValue0",
-		"labelKey1":                  "labelKeyValue1",
+		constants.CanonicalLabelApplicationID: appID,
+		constants.CanonicalLabelQueueName:     queue,
+		"labelKey0":                           "labelKeyValue0",
+		"labelKey1":                           "labelKeyValue1",
 	})
 	assert.Equal(t, len(holder.pod.Annotations), 6, "unexpected number of annotations")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -396,7 +396,15 @@ func callbacks(states *TStates) fsm.Callbacks {
 		},
 		states.Rejected: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
-			task.postTaskRejected()
+			eventArgs := make([]string, 1)
+			reason := ""
+			if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
+				log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
+				reason = err.Error()
+			} else {
+				reason = eventArgs[0]
+			}
+			task.postTaskRejected(reason)
 		},
 		states.Failed: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -87,6 +87,8 @@ var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft":
 
 const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"
+const TaskRejectedFailure = "TaskRejected"
+const TaskPodInconsistMetadataFailure = "PodInconsistentMetadata"
 
 // namespace.max.* (Retaining for backwards compatibility. Need to be removed in next major release)
 const CPUQuota = DomainYuniKorn + "namespace.max.cpu"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -104,12 +104,21 @@ func IsAssignedPod(pod *v1.Pod) bool {
 }
 
 func GetQueueNameFromPod(pod *v1.Pod) string {
+	// Queue name can be defined in multiple places
+	// The queue name is determined by the following order
+	// 1. Label: constants.CanonicalLabelQueueName
+	// 2. Label: constants.LabelQueueName
+	// 3. Annotation: constants.AnnotationQueueName
+	// 4. Default: constants.ApplicationDefaultQueue
 	queueName := constants.ApplicationDefaultQueue
-	if an := GetPodLabelValue(pod, constants.LabelQueueName); an != "" {
-		queueName = an
-	} else if qu := GetPodAnnotationValue(pod, constants.AnnotationQueueName); qu != "" {
-		queueName = qu
+	if canonicalLabelQueueName := GetPodLabelValue(pod, constants.CanonicalLabelQueueName); canonicalLabelQueueName != "" {
+		queueName = canonicalLabelQueueName
+	} else if labelQueueName := GetPodLabelValue(pod, constants.LabelQueueName); labelQueueName != "" {
+		queueName = labelQueueName
+	} else if annotationQueueName := GetPodAnnotationValue(pod, constants.AnnotationQueueName); annotationQueueName != "" {
+		queueName = annotationQueueName
 	}
+
 	return queueName
 }
 
@@ -154,15 +163,26 @@ func GetApplicationIDFromPod(pod *v1.Pod) string {
 		}
 	}
 
-	// Application ID can be defined in annotation
-	appID := GetPodAnnotationValue(pod, constants.AnnotationApplicationID)
-	if appID == "" {
-		// Application ID can be defined in label
-		appID = GetPodLabelValue(pod, constants.LabelApplicationID)
+	// Application ID can be defined in multiple places
+	// The application ID is determined by the following order.
+	// 1. Label: constants.CanonicalLabelApplicationID
+	// 2. Label: constants.LabelApplicationID
+	// 3. Label: constants.SparkLabelAppID
+	// 4. Annotation: constants.AnnotationApplicationID
+	labelKeys := []string{
+		constants.CanonicalLabelApplicationID,
+		constants.LabelApplicationID,
+		constants.SparkLabelAppID,
+	}
+	appID := ""
+	for _, label := range labelKeys {
+		appID = GetPodLabelValue(pod, label)
+		if appID != "" {
+			break
+		}
 	}
 	if appID == "" {
-		// Spark can also define application ID
-		appID = GetPodLabelValue(pod, constants.SparkLabelAppID)
+		appID = GetPodAnnotationValue(pod, constants.AnnotationApplicationID)
 	}
 
 	// If plugin mode, interpret missing Application ID as a non-YuniKorn pod
@@ -183,6 +203,37 @@ func GetApplicationIDFromPod(pod *v1.Pod) string {
 
 	// Standard deployment mode, so we need a valid Application ID to proceed. Generate one now.
 	return GenerateApplicationID(pod.Namespace, conf.GetSchedulerConf().GenerateUniqueAppIds, string(pod.UID))
+}
+
+// ValidatePodLabelAnnotationConsistency return true if all non-empty values are consistent across provided label/annotation
+func ValidatePodLabelAnnotationConsistency(pod *v1.Pod, labelKeys []string, annotationKeys []string) bool {
+	var firstValue string
+
+	for _, key := range labelKeys {
+		value := GetPodLabelValue(pod, key)
+		if value == "" {
+			continue
+		}
+		if firstValue == "" {
+			firstValue = value
+		} else if firstValue != value {
+			return false
+		}
+	}
+
+	for _, key := range annotationKeys {
+		value := GetPodAnnotationValue(pod, key)
+		if value == "" {
+			continue
+		}
+		if firstValue == "" {
+			firstValue = value
+		} else if firstValue != value {
+			return false
+		}
+	}
+
+	return true
 }
 
 // compare the existing pod condition with the given one, return true if the pod condition remains not changed.

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -514,6 +514,7 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 	defer SetPluginMode(false)
 	defer func() { conf.GetSchedulerConf().GenerateUniqueAppIds = false }()
 
+	appIDInCanonicalLabel := "CanonicalLabelAppID"
 	appIDInLabel := "labelAppID"
 	appIDInAnnotation := "annotationAppID"
 	appIDInSelector := "selectorAppID"
@@ -525,6 +526,12 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 		expectedAppIDPluginMode string
 		generateUniqueAppIds    bool
 	}{
+		{"AppID defined in canonical label", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{constants.CanonicalLabelApplicationID: appIDInCanonicalLabel},
+			},
+			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
+		}, appIDInCanonicalLabel, appIDInCanonicalLabel, false},
 		{"AppID defined in label", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{constants.LabelApplicationID: appIDInLabel},
@@ -545,7 +552,15 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
 		}, "testns-podUid", "", true},
-		{"Unique autogen token found with generateUnique", &v1.Pod{
+		{"Unique autogen token found with generateUnique in canonical AppId label", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns",
+				UID:       "podUid",
+				Labels:    map[string]string{constants.CanonicalLabelApplicationID: "testns-uniqueautogen"},
+			},
+			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
+		}, "testns-podUid", "testns-podUid", true},
+		{"Unique autogen token found with generateUnique in legacy AppId labels", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "testns",
 				UID:       "podUid",
@@ -553,7 +568,13 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
 		}, "testns-podUid", "testns-podUid", true},
-		{"Non-yunikorn schedulerName", &v1.Pod{
+		{"Non-yunikorn schedulerName with canonical AppId label", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{constants.CanonicalLabelApplicationID: appIDInCanonicalLabel},
+			},
+			Spec: v1.PodSpec{SchedulerName: "default"},
+		}, "", "", false},
+		{"Non-yunikorn schedulerName with legacy AppId label", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{constants.LabelApplicationID: appIDInLabel},
 			},
@@ -583,13 +604,20 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
 		}, appIDInAnnotation, appIDInAnnotation, false},
-		{"AppID defined in label and annotation", &v1.Pod{
+		{"AppID defined in canonical label and annotation", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{constants.AnnotationApplicationID: appIDInAnnotation},
+				Labels:      map[string]string{constants.CanonicalLabelApplicationID: appIDInCanonicalLabel},
+			},
+			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
+		}, appIDInCanonicalLabel, appIDInCanonicalLabel, false},
+		{"AppID defined in legacy label and annotation", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{constants.AnnotationApplicationID: appIDInAnnotation},
 				Labels:      map[string]string{constants.LabelApplicationID: appIDInLabel},
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
-		}, appIDInAnnotation, appIDInAnnotation, false},
+		}, appIDInLabel, appIDInLabel, false},
 
 		{"Spark AppID defined in spark app selector", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -603,14 +631,14 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 				Annotations: map[string]string{constants.AnnotationApplicationID: sparkIDInAnnotation},
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
-		}, sparkIDInAnnotation, sparkIDInAnnotation, false},
+		}, appIDInSelector, appIDInSelector, false},
 		{"Spark AppID defined in spark app selector and annotation", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      map[string]string{constants.SparkLabelAppID: appIDInSelector, constants.LabelApplicationID: appIDInLabel},
 				Annotations: map[string]string{constants.AnnotationApplicationID: sparkIDInAnnotation},
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
-		}, sparkIDInAnnotation, sparkIDInAnnotation, false},
+		}, appIDInLabel, appIDInLabel, false},
 		{"No AppID defined", &v1.Pod{}, "", "", false},
 		{"Spark AppID defined in spark app selector and label", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -629,6 +657,96 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			SetPluginMode(true)
 			appID2 := GetApplicationIDFromPod(tc.pod)
 			assert.Equal(t, appID2, tc.expectedAppIDPluginMode, "Wrong appID (plugin mode)")
+		})
+	}
+}
+
+func TestValidatePodLabelAnnotationConsistency(t *testing.T) {
+	labelKeys := []string{"labelKey1", "labelKey2"}
+	annotationKeys := []string{"annotationKey1", "annotationKey2"}
+
+	testCases := []struct {
+		name           string
+		pod            *v1.Pod
+		lablabelKeys   []string
+		annotationKeys []string
+		expected       bool
+	}{
+		{
+			"empty pod indicates no inconsistency between labels and annotations",
+			&v1.Pod{},
+			labelKeys,
+			annotationKeys,
+			true,
+		},
+		{
+			"pod with values that are consistent across all labels and annotations",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"labelKey1": "value1",
+						"labelKey2": "value1",
+					},
+					Annotations: map[string]string{
+						"annotationKey1": "value1",
+						"annotationKey2": "value1",
+					},
+				},
+			},
+			labelKeys,
+			annotationKeys,
+			true,
+		},
+		{
+			"pod with inconsistent value in labels",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"labelKey1": "value1",
+						"labelKey2": "value2",
+					},
+				},
+			},
+			labelKeys,
+			annotationKeys,
+			false,
+		},
+		{
+			"pod with inconsistent value between label and annotation",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"labelKey1": "value1",
+					},
+					Annotations: map[string]string{
+						"annotationKey1": "value2",
+					},
+				},
+			},
+			labelKeys,
+			annotationKeys,
+			false,
+		},
+		{
+			"pod with inconsistent value in annotations",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotationKey1": "value1",
+						"annotationKey2": "value2",
+					},
+				},
+			},
+			labelKeys,
+			annotationKeys,
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isConsistet := ValidatePodLabelAnnotationConsistency(tc.pod, tc.lablabelKeys, tc.annotationKeys)
+			assert.Equal(t, isConsistet, tc.expected)
 		})
 	}
 }
@@ -817,6 +935,7 @@ func TestGetUserFromPodAnnotation(t *testing.T) {
 }
 
 func TestGetQueueNameFromPod(t *testing.T) {
+	queueInCanonicalLabel := "sandboxCanonicalLabel"
 	queueInLabel := "sandboxLabel"
 	queueInAnnotation := "sandboxAnnotation"
 	testCases := []struct {
@@ -825,7 +944,16 @@ func TestGetQueueNameFromPod(t *testing.T) {
 		expectedQueue string
 	}{
 		{
-			name: "With queue label",
+			name: "With canonical queue label",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{constants.CanonicalLabelQueueName: queueInCanonicalLabel},
+				},
+			},
+			expectedQueue: queueInCanonicalLabel,
+		},
+		{
+			name: "With legacy queue label",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{constants.LabelQueueName: queueInLabel},
@@ -843,7 +971,17 @@ func TestGetQueueNameFromPod(t *testing.T) {
 			expectedQueue: queueInAnnotation,
 		},
 		{
-			name: "With queue label and annotation",
+			name: "With canonical queue label and annotation",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{constants.CanonicalLabelQueueName: queueInCanonicalLabel},
+					Annotations: map[string]string{constants.AnnotationQueueName: queueInAnnotation},
+				},
+			},
+			expectedQueue: queueInCanonicalLabel,
+		},
+		{
+			name: "With legacy queue label and annotation",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      map[string]string{constants.LabelQueueName: queueInLabel},

--- a/test/e2e/framework/helpers/k8s/k8s_utils.go
+++ b/test/e2e/framework/helpers/k8s/k8s_utils.go
@@ -188,6 +188,18 @@ func (k *KubeCtl) GetPod(name, namespace string) (*v1.Pod, error) {
 	return k.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+func (k *KubeCtl) GetPodFailureReasonAndMessage(name, namespace string) (string, string, error) {
+	pod, err := k.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	if pod.Status.Phase == v1.PodFailed {
+		return pod.Status.Reason, pod.Status.Message, nil
+	} else {
+		return "", "", fmt.Errorf("pod %s is not in failed state", name)
+	}
+}
+
 func (k *KubeCtl) GetSchedulerPod() (string, error) {
 	podNameList, err := k.GetPodNamesFromNS(configmanager.YuniKornTestConfig.YkNamespace)
 	if err != nil {


### PR DESCRIPTION
### What is this PR for?
Support canonical Queue/ApplicationId labels in Pod: (The existing label are kept without deprecation.)
- yunikorn.apache.org/app-id (New, **Canonical Label**)
- yunikorn.apache.org/queue (New, **Canonical Label)**

Check config consistency in sanityCheckBeforeScheduling(). Reject task if the task pod is not bound and
1. Not bound and
2. Conflict appId detect

2. 





### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
