### PR TITLE
[YUNIKORN-2504] Support canonical labels for queue/applicationId in scheduler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/apache/yunikorn
   govet:
-    check-shadowing: true
+    shadow: true
   goconst:
     min-occurrences: 5
   funlen:

--- a/Makefile
+++ b/Makefile
@@ -288,10 +288,7 @@ $(GINKGO_BIN):
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
-	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
-	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
-	echo "checking against commit sha $${headSHA}" ; \
-	"${GOLANGCI_LINT_BIN}" run
+	@"${GOLANGCI_LINT_BIN}" run
 
 # Check scripts
 .PHONY: check_scripts

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,8 @@ endif
 
 # shellcheck
 SHELLCHECK_VERSION=v0.9.0
-SHELLCHECK_BIN=${TOOLS_DIR}/shellcheck
+SHELLCHECK_PATH=${TOOLS_DIR}/shellcheck-$(SHELLCHECK_VERSION)
+SHELLCHECK_BIN=${SHELLCHECK_PATH}/shellcheck
 SHELLCHECK_ARCHIVE := shellcheck-$(SHELLCHECK_VERSION).$(OS).$(HOST_ARCH).tar.xz
 ifeq (darwin, $(OS))
 ifeq (arm64, $(HOST_ARCH))
@@ -143,41 +144,56 @@ ifeq (armv7l, $(HOST_ARCH))
 SHELLCHECK_ARCHIVE := shellcheck-$(SHELLCHECK_VERSION).$(OS).armv6hf.tar.xz
 endif
 endif
+export PATH := $(BASE_DIR)/$(SHELLCHECK_PATH):$(PATH)
 
 # golangci-lint
 GOLANGCI_LINT_VERSION=1.57.2
-GOLANGCI_LINT_BIN=$(TOOLS_DIR)/golangci-lint
+GOLANGCI_LINT_PATH=$(TOOLS_DIR)/golangci-lint-v$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT_BIN=$(GOLANGCI_LINT_PATH)/golangci-lint
 GOLANGCI_LINT_ARCHIVE=golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(EXEC_ARCH).tar.gz
 GOLANGCI_LINT_ARCHIVEBASE=golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(EXEC_ARCH)
+export PATH := $(BASE_DIR)/$(GOLANGCI_LINT_PATH):$(PATH)
 
 # kubectl
 KUBECTL_VERSION=v1.27.7
-KUBECTL_BIN=$(TOOLS_DIR)/kubectl
+KUBECTL_PATH=$(TOOLS_DIR)/kubectl-$(KUBECTL_VERSION)
+KUBECTL_BIN=$(KUBECTL_PATH)/kubectl
+export PATH := $(BASE_DIR)/$(KUBECTL_PATH):$(PATH)
 
 # kind
 KIND_VERSION=v0.23.0
-KIND_BIN=$(TOOLS_DIR)/kind
+KIND_PATH=$(TOOLS_DIR)/kind-$(KIND_VERSION)
+KIND_BIN=$(KIND_PATH)/kind
+export PATH := $(BASE_DIR)/$(KIND_PATH):$(PATH)
 
 # helm
 HELM_VERSION=v3.12.1
-HELM_BIN=$(TOOLS_DIR)/helm
+HELM_PATH=$(TOOLS_DIR)/helm-$(HELM_VERSION)
+HELM_BIN=$(HELM_PATH)/helm
 HELM_ARCHIVE=helm-$(HELM_VERSION)-$(OS)-$(EXEC_ARCH).tar.gz
 HELM_ARCHIVE_BASE=$(OS)-$(EXEC_ARCH)
+export PATH := $(BASE_DIR)/$(HELM_PATH):$(PATH)
 
 # spark
 export SPARK_VERSION=3.3.3
 # sometimes the image is not avaiable with $SPARK_VERSION, the minor version must match
 export SPARK_PYTHON_VERSION=3.3.1
-export SPARK_HOME=$(BASE_DIR)$(TOOLS_DIR)/spark
+export SPARK_HOME=$(BASE_DIR)$(TOOLS_DIR)/spark-v$(SPARK_VERSION)
 export SPARK_SUBMIT_CMD=$(SPARK_HOME)/bin/spark-submit
 export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v$(SPARK_PYTHON_VERSION)
+export PATH := $(SPARK_HOME):$(PATH)
 
 # go-licenses
 GO_LICENSES_VERSION=v1.6.0
-GO_LICENSES_BIN=$(TOOLS_DIR)/go-licenses
+GO_LICENSES_PATH=$(TOOLS_DIR)/go-licenses-$(GO_LICENSES_VERSION)
+GO_LICENSES_BIN=$(GO_LICENSES_PATH)/go-licenses
+export PATH := $(BASE_DIR)/$(GO_LICENSES_PATH):$(PATH)
 
 # ginkgo
-GINKGO_BIN=$(TOOLS_DIR)/ginkgo
+GINKGO_VERSION=v2.19.0
+GINKGO_PATH=$(TOOLS_DIR)/ginkgo-$(GINKGO_VERSION)
+GINKGO_BIN=$(GINKGO_PATH)/ginkgo
+export PATH := $(BASE_DIR)/$(GINKGO_PATH):$(PATH)
 
 FLAG_PREFIX=github.com/apache/yunikorn-k8shim/pkg/conf
 
@@ -222,6 +238,17 @@ init: conf/scheduler-config-local.yaml
 conf/scheduler-config-local.yaml: conf/scheduler-config.yaml
 	./scripts/plugin-conf-gen.sh $(KUBECONFIG) "conf/scheduler-config.yaml" "conf/scheduler-config-local.yaml"
 
+# Print tools version
+.PHONY: print_kubectl_version
+print_kubectl_version:
+	@echo $(KUBECTL_VERSION)
+.PHONY: print_kind_version
+print_kind_version:
+	@echo $(KIND_VERSION)
+.PHONY: print_helm_version
+print_helm_version:
+	@echo $(HELM_VERSION)
+
 # Install tools
 .PHONY: tools
 tools: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN) $(KUBECTL_BIN) $(KIND_BIN) $(HELM_BIN) $(SPARK_SUBMIT_CMD) $(GO_LICENSES_BIN) $(GINKGO_BIN)
@@ -229,21 +256,21 @@ tools: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN) $(KUBECTL_BIN) $(KIND_BIN) $(HELM_
 # Install shellcheck
 $(SHELLCHECK_BIN):
 	@echo "installing shellcheck $(SHELLCHECK_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
+	@mkdir -p "$(SHELLCHECK_PATH)"
 	@curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/$(SHELLCHECK_ARCHIVE)" \
-		| tar -x -J --strip-components=1 -C "$(TOOLS_DIR)" "shellcheck-$(SHELLCHECK_VERSION)/shellcheck"
+		| tar -x -J --strip-components=1 -C "$(SHELLCHECK_PATH)" "shellcheck-$(SHELLCHECK_VERSION)/shellcheck"
 
 # Install golangci-lint
 $(GOLANGCI_LINT_BIN):
 	@echo "installing golangci-lint v$(GOLANGCI_LINT_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
+	@mkdir -p "$(GOLANGCI_LINT_PATH)"
 	@curl -sSfL "https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/$(GOLANGCI_LINT_ARCHIVE)" \
-		| tar -x -z --strip-components=1 -C "$(TOOLS_DIR)" "$(GOLANGCI_LINT_ARCHIVEBASE)/golangci-lint"
+		| tar -x -z --strip-components=1 -C "$(GOLANGCI_LINT_PATH)" "$(GOLANGCI_LINT_ARCHIVEBASE)/golangci-lint"
 
 # Install kubectl
 $(KUBECTL_BIN):
 	@echo "installing kubectl $(KUBECTL_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
+	@mkdir -p "$(KUBECTL_PATH)"
 	@curl -sSfL -o "$(KUBECTL_BIN)" \
 		"https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(OS)/$(EXEC_ARCH)/kubectl" && \
 		chmod +x "$(KUBECTL_BIN)"
@@ -251,7 +278,7 @@ $(KUBECTL_BIN):
 # Install kind
 $(KIND_BIN):
 	@echo "installing kind $(KIND_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
+	@mkdir -p "$(KIND_PATH)"
 	@curl -sSfL -o "$(KIND_BIN)" \
 		"https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(OS)-$(EXEC_ARCH)" && \
 		chmod +x "$(KIND_BIN)"
@@ -259,13 +286,13 @@ $(KIND_BIN):
 # Install helm
 $(HELM_BIN):
 	@echo "installing helm $(HELM_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
+	@mkdir -p "$(HELM_PATH)"
 	@curl -sSfL "https://get.helm.sh/$(HELM_ARCHIVE)" \
-		| tar -x -z --strip-components=1 -C "$(TOOLS_DIR)" "$(HELM_ARCHIVE_BASE)/helm"
+		| tar -x -z --strip-components=1 -C "$(HELM_PATH)" "$(HELM_ARCHIVE_BASE)/helm"
 
 # Install spark
 $(SPARK_SUBMIT_CMD):
-	@echo "installing spark $(SPARK_VERSION)"
+	@echo "installing spark v$(SPARK_VERSION)"
 	@rm -rf "$(SPARK_HOME)" "$(SPARK_HOME).tmp"
 	@mkdir -p "$(SPARK_HOME).tmp"
 	@curl -sSfL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz" \
@@ -275,13 +302,13 @@ $(SPARK_SUBMIT_CMD):
 # Install go-licenses
 $(GO_LICENSES_BIN):
 	@echo "installing go-licenses $(GO_LICENSES_VERSION)"
-	@mkdir -p "$(TOOLS_DIR)"
-	@GOBIN="$(BASE_DIR)/$(TOOLS_DIR)" "$(GO)" install "github.com/google/go-licenses@$(GO_LICENSES_VERSION)"
+	@mkdir -p "$(GO_LICENSES_PATH)"
+	@GOBIN="$(BASE_DIR)/$(GO_LICENSES_PATH)" "$(GO)" install "github.com/google/go-licenses@$(GO_LICENSES_VERSION)"
 
 $(GINKGO_BIN):
-	@echo "installing ginkgo"
-	@mkdir -p "$(TOOLS_DIR)"
-	@GOBIN="$(BASE_DIR)/$(TOOLS_DIR)" "$(GO)" install "github.com/onsi/ginkgo/v2/ginkgo"
+	@echo "installing ginkgo $(GINKGO_VERSION)"
+	@mkdir -p "$(GINKGO_PATH)"
+	@GOBIN="$(BASE_DIR)/$(GINKGO_PATH)" "$(GO)" install "github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)"
 
 # Run lint against the previous commit for PR and branch build
 # In dev setup look at all changes on top of master

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ module github.com/apache/yunikorn-k8shim
 go 1.21
 
 require (
-	github.com/apache/yunikorn-core v0.0.0-20240711165824-d96cd583305b
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1
+	github.com/apache/yunikorn-core v0.0.0-20240802210614-4aec626c6bf9
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/looplab/fsm v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,10 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/apache/yunikorn-core v0.0.0-20240711165824-d96cd583305b h1:GDizY3dcE+hkfik/+NY3Zdw71A/V4dWGp9Pl6k5Ii2M=
-github.com/apache/yunikorn-core v0.0.0-20240711165824-d96cd583305b/go.mod h1:pSi7AFBRiGCGQ7RwQffpD4m6dvA5lc1HuCrg7LpJJqs=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1 h1:v4J9L3MlW8BQfYnbq6FV2l3uyay3SqMS2Ffpo+SFat4=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
+github.com/apache/yunikorn-core v0.0.0-20240802210614-4aec626c6bf9 h1:s1Co/K+cR9Q/GW0e974dToW9eyLQZxYoCp0TCoEuEj0=
+github.com/apache/yunikorn-core v0.0.0-20240802210614-4aec626c6bf9/go.mod h1:S9yGBGA2i2hAajtEc2t4lmiPJDZz3Ek8eVxz5KhJqGI=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586 h1:ZVpo9Qj2/gvwX6Rl44UxkZBm2pZWEJDYWTramc9hwF0=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -19,6 +19,7 @@
 package conf
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -117,7 +118,7 @@ func NewAdmissionControllerConf(configMaps []*v1.ConfigMap) *AdmissionController
 func (acc *AdmissionControllerConf) RegisterHandlers(configMaps informersv1.ConfigMapInformer) error {
 	_, err := configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
 	if err != nil {
-		return fmt.Errorf("failed to create register handlers: %w", err)
+		return errors.Join(errors.New("failed to create register handlers: "), err)
 	}
 
 	return nil

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -19,7 +19,7 @@
 package admission
 
 import (
-	"fmt"
+	"errors"
 
 	v1 "k8s.io/api/core/v1"
 	informersv1 "k8s.io/client-go/informers/core/v1"
@@ -62,7 +62,7 @@ func NewNamespaceCache(namespaces informersv1.NamespaceInformer) (*NamespaceCach
 	if namespaces != nil {
 		_, err := namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create namespace cache: %w", err)
+			return nil, errors.Join(errors.New("failed to create namespace cache: "), err)
 		}
 	}
 	return nsc, nil

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -19,7 +19,7 @@
 package admission
 
 import (
-	"fmt"
+	"errors"
 
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	informersv1 "k8s.io/client-go/informers/scheduling/v1"
@@ -45,7 +45,7 @@ func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) (*
 	if priorityClasses != nil {
 		_, err := priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create a new cache and register the handler: %w", err)
+			return nil, errors.Join(errors.New("failed to create a new cache and register the handler: "), err)
 		}
 	}
 	return pcc, nil

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -115,14 +115,10 @@ func (app *Application) canHandle(ev events.ApplicationEvent) bool {
 	return app.sm.Can(ev.GetEvent())
 }
 
-func (app *Application) GetTask(taskID string) (*Task, error) {
+func (app *Application) GetTask(taskID string) *Task {
 	app.lock.RLock()
 	defer app.lock.RUnlock()
-	if task, ok := app.taskMap[taskID]; ok {
-		return task, nil
-	}
-	return nil, fmt.Errorf("task %s doesn't exist in application %s",
-		taskID, app.applicationID)
+	return app.taskMap[taskID]
 }
 
 func (app *Application) GetApplicationID() string {

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -1184,9 +1184,7 @@ func TestPlaceholderTimeoutEvents(t *testing.T) {
 	})
 	assert.Assert(t, task1 != nil)
 	assert.Equal(t, task1.GetTaskID(), "task02")
-
-	_, taskErr := app.GetTask("task02")
-	assert.NilError(t, taskErr, "Task should exist")
+	assert.Assert(t, app.GetTask("task02") != nil, "Task should exist")
 
 	task1.allocationKey = allocationKey
 

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -351,7 +351,7 @@ func (ctx *Context) ensureAppAndTaskCreated(pod *v1.Pod) {
 	}
 
 	// add task if it doesn't already exist
-	if _, taskErr := app.GetTask(string(pod.UID)); taskErr != nil {
+	if task := app.GetTask(string(pod.UID)); task == nil {
 		ctx.addTask(&AddTaskRequest{
 			Metadata: taskMeta,
 		})
@@ -1097,8 +1097,8 @@ func (ctx *Context) addTask(request *AddTaskRequest) *Task {
 		zap.String("appID", request.Metadata.ApplicationID),
 		zap.String("taskID", request.Metadata.TaskID))
 	if app := ctx.getApplication(request.Metadata.ApplicationID); app != nil {
-		existingTask, err := app.GetTask(request.Metadata.TaskID)
-		if err != nil {
+		existingTask := app.GetTask(request.Metadata.TaskID)
+		if existingTask == nil {
 			var originator bool
 
 			// Is this task the originator of the application?
@@ -1156,8 +1156,8 @@ func (ctx *Context) getTask(appID string, taskID string) *Task {
 			zap.String("appID", appID))
 		return nil
 	}
-	task, err := app.GetTask(taskID)
-	if err != nil {
+	task := app.GetTask(taskID)
+	if task == nil {
 		log.Log(log.ShimContext).Debug("task is not found in applications",
 			zap.String("taskID", taskID),
 			zap.String("appID", appID))

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -166,8 +166,6 @@ func (ctx *Context) addNode(obj interface{}) {
 }
 
 func (ctx *Context) updateNode(_, obj interface{}) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	node, err := convertToNode(obj)
 	if err != nil {
 		log.Log(log.ShimContext).Error("node conversion failed", zap.Error(err))
@@ -202,7 +200,7 @@ func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 			if applicationID == "" {
 				ctx.updateForeignPod(pod)
 			} else {
-				ctx.updateYuniKornPod(pod)
+				ctx.updateYuniKornPod(applicationID, pod)
 			}
 		}
 
@@ -229,8 +227,6 @@ func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 }
 
 func (ctx *Context) deleteNode(obj interface{}) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	var node *v1.Node
 	switch t := obj.(type) {
 	case *v1.Node:
@@ -250,9 +246,6 @@ func (ctx *Context) deleteNode(obj interface{}) {
 }
 
 func (ctx *Context) addNodesWithoutRegistering(nodes []*v1.Node) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-
 	for _, node := range nodes {
 		ctx.updateNodeInternal(node, false)
 	}
@@ -288,30 +281,31 @@ func (ctx *Context) AddPod(obj interface{}) {
 }
 
 func (ctx *Context) UpdatePod(_, newObj interface{}) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-
 	pod, err := utils.Convert2Pod(newObj)
 	if err != nil {
 		log.Log(log.ShimContext).Error("failed to update pod", zap.Error(err))
 		return
 	}
-	if utils.GetApplicationIDFromPod(pod) == "" {
+	applicationID := utils.GetApplicationIDFromPod(pod)
+	if applicationID == "" {
 		ctx.updateForeignPod(pod)
 	} else {
-		ctx.updateYuniKornPod(pod)
+		ctx.updateYuniKornPod(applicationID, pod)
 	}
 }
 
-func (ctx *Context) updateYuniKornPod(pod *v1.Pod) {
+func (ctx *Context) updateYuniKornPod(appID string, pod *v1.Pod) {
+	var app *Application
+	taskID := string(pod.UID)
+	if app = ctx.getApplication(appID); app != nil {
+		if task := app.GetTask(taskID); task != nil {
+			task.setTaskPod(pod)
+		}
+	}
+
 	// treat terminated pods like a remove
 	if utils.IsPodTerminated(pod) {
-		if taskMeta, ok := getTaskMetadata(pod); ok {
-			if app := ctx.getApplication(taskMeta.ApplicationID); app != nil {
-				ctx.notifyTaskComplete(taskMeta.ApplicationID, taskMeta.TaskID)
-			}
-		}
-
+		ctx.notifyTaskComplete(appID, taskID)
 		log.Log(log.ShimContext).Debug("Request to update terminated pod, removing from cache", zap.String("podName", pod.Name))
 		ctx.schedulerCache.RemovePod(pod)
 		return
@@ -334,9 +328,9 @@ func (ctx *Context) ensureAppAndTaskCreated(pod *v1.Pod) {
 	}
 
 	// add app if it doesn't already exist
-	app := ctx.getApplication(appMeta.ApplicationID)
+	app := ctx.GetApplication(appMeta.ApplicationID)
 	if app == nil {
-		app = ctx.addApplication(&AddApplicationRequest{
+		app = ctx.AddApplication(&AddApplicationRequest{
 			Metadata: appMeta,
 		})
 	}
@@ -440,10 +434,8 @@ func (ctx *Context) DeletePod(obj interface{}) {
 }
 
 func (ctx *Context) deleteYuniKornPod(pod *v1.Pod) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	if taskMeta, ok := getTaskMetadata(pod); ok {
-		if app := ctx.getApplication(taskMeta.ApplicationID); app != nil {
+		if app := ctx.GetApplication(taskMeta.ApplicationID); app != nil {
 			ctx.notifyTaskComplete(taskMeta.ApplicationID, taskMeta.TaskID)
 		}
 	}
@@ -453,9 +445,6 @@ func (ctx *Context) deleteYuniKornPod(pod *v1.Pod) {
 }
 
 func (ctx *Context) deleteForeignPod(pod *v1.Pod) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-
 	oldPod := ctx.schedulerCache.GetPod(string(pod.UID))
 	if oldPod == nil {
 		// if pod is not in scheduler cache, no node updates are needed
@@ -586,8 +575,6 @@ func (ctx *Context) addPriorityClass(obj interface{}) {
 }
 
 func (ctx *Context) updatePriorityClass(_, newObj interface{}) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	if priorityClass := utils.Convert2PriorityClass(newObj); priorityClass != nil {
 		ctx.updatePriorityClassInternal(priorityClass)
 	}
@@ -598,9 +585,6 @@ func (ctx *Context) updatePriorityClassInternal(priorityClass *schedulingv1.Prio
 }
 
 func (ctx *Context) deletePriorityClass(obj interface{}) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-
 	log.Log(log.ShimContext).Debug("priorityClass deleted")
 	var priorityClass *schedulingv1.PriorityClass
 	switch t := obj.(type) {
@@ -666,8 +650,6 @@ func (ctx *Context) EventsToRegister(queueingHintFn framework.QueueingHintFn) []
 
 // IsPodFitNode evaluates given predicates based on current context
 func (ctx *Context) IsPodFitNode(name, node string, allocate bool) error {
-	ctx.lock.RLock()
-	defer ctx.lock.RUnlock()
 	pod := ctx.schedulerCache.GetPod(name)
 	if pod == nil {
 		return ErrorPodNotFound
@@ -688,8 +670,6 @@ func (ctx *Context) IsPodFitNode(name, node string, allocate bool) error {
 }
 
 func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []string, startIndex int) (int, bool) {
-	ctx.lock.RLock()
-	defer ctx.lock.RUnlock()
 	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		// if pod exists in cache, try to run predicates
 		if targetNode := ctx.schedulerCache.GetNode(node); targetNode != nil {
@@ -798,8 +778,6 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 // this way, the core can make allocation decisions with consideration of
 // other assumed pods before they are actually bound to the node (bound is slow).
 func (ctx *Context) AssumePod(name, node string) error {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		// when add assumed pod, we make a copy of the pod to avoid
 		// modifying its original reference. otherwise, it may have
@@ -859,21 +837,12 @@ func (ctx *Context) AssumePod(name, node string) error {
 // forget pod must be called when a pod is assumed to be running on a node,
 // but then for some reason it is failed to bind or released.
 func (ctx *Context) ForgetPod(name string) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-
 	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		log.Log(log.ShimContext).Debug("forget pod", zap.String("pod", pod.Name))
 		ctx.schedulerCache.ForgetPod(pod)
 		return
 	}
 	log.Log(log.ShimContext).Debug("unable to forget pod: not found in cache", zap.String("pod", name))
-}
-
-func (ctx *Context) UpdateApplication(app *Application) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-	ctx.applications[app.applicationID] = app
 }
 
 // IsTaskMaybeSchedulable returns true if a task might be currently able to be scheduled. This uses a bloom filter
@@ -904,17 +873,11 @@ func (ctx *Context) StartPodAllocation(podKey string, nodeID string) bool {
 	return ctx.schedulerCache.StartPodAllocation(podKey, nodeID)
 }
 
-func (ctx *Context) NotifyTaskComplete(appID, taskID string) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-	ctx.notifyTaskComplete(appID, taskID)
-}
-
 func (ctx *Context) notifyTaskComplete(appID, taskID string) {
 	log.Log(log.ShimContext).Debug("NotifyTaskComplete",
 		zap.String("appID", appID),
 		zap.String("taskID", taskID))
-	if app := ctx.getApplication(appID); app != nil {
+	if app := ctx.GetApplication(appID); app != nil {
 		log.Log(log.ShimContext).Debug("release allocation",
 			zap.String("appID", appID),
 			zap.String("taskID", taskID))
@@ -930,6 +893,8 @@ func (ctx *Context) notifyTaskComplete(appID, taskID string) {
 // adds the following tags to the request based on annotations (if exist):
 //   - namespace.resourcequota
 //   - namespace.parentqueue
+//   - namespace.resourceguaranteed
+//   - namespace.resourcemaxapps
 func (ctx *Context) updateApplicationTags(request *AddApplicationRequest, namespace string) {
 	namespaceObj := ctx.getNamespaceObject(namespace)
 	if namespaceObj == nil {
@@ -949,6 +914,12 @@ func (ctx *Context) updateApplicationTags(request *AddApplicationRequest, namesp
 		if guaranteed, err := json.Marshal(guaranteedResource); err == nil {
 			request.Metadata.Tags[siCommon.AppTagNamespaceResourceGuaranteed] = string(guaranteed)
 		}
+	}
+
+	// add maxApps resource info as an app tag
+	maxApps := utils.GetNamespaceMaxAppsFromAnnotation(namespaceObj)
+	if maxApps != "" {
+		request.Metadata.Tags[siCommon.AppTagNamespaceResourceMaxApps] = maxApps
 	}
 
 	// add parent queue info as an app tag
@@ -982,10 +953,6 @@ func (ctx *Context) AddApplication(request *AddApplicationRequest) *Application 
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
-	return ctx.addApplication(request)
-}
-
-func (ctx *Context) addApplication(request *AddApplicationRequest) *Application {
 	log.Log(log.ShimContext).Debug("AddApplication", zap.Any("Request", request))
 	if app := ctx.getApplication(request.Metadata.ApplicationID); app != nil {
 		return app
@@ -1051,31 +1018,7 @@ func (ctx *Context) getApplication(appID string) *Application {
 	return nil
 }
 
-func (ctx *Context) RemoveApplication(appID string) error {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
-	if app, exist := ctx.applications[appID]; exist {
-		// get the non-terminated task alias
-		nonTerminatedTaskAlias := app.getNonTerminatedTaskAlias()
-		// check there are any non-terminated task or not
-		if len(nonTerminatedTaskAlias) > 0 {
-			return fmt.Errorf("failed to remove application %s because it still has task in non-terminated task, tasks: %s", appID, strings.Join(nonTerminatedTaskAlias, ","))
-		}
-		// send the update request to scheduler core
-		rr := common.CreateUpdateRequestForRemoveApplication(app.applicationID, app.partition)
-		if err := ctx.apiProvider.GetAPIs().SchedulerAPI.UpdateApplication(rr); err != nil {
-			log.Log(log.ShimContext).Error("failed to send remove application request to core", zap.Error(err))
-		}
-		delete(ctx.applications, appID)
-		log.Log(log.ShimContext).Info("app removed",
-			zap.String("appID", appID))
-
-		return nil
-	}
-	return fmt.Errorf("application %s is not found in the context", appID)
-}
-
-func (ctx *Context) RemoveApplicationInternal(appID string) {
+func (ctx *Context) RemoveApplication(appID string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	if _, exist := ctx.applications[appID]; !exist {
@@ -1087,8 +1030,6 @@ func (ctx *Context) RemoveApplicationInternal(appID string) {
 
 // this implements ApplicationManagementProtocol
 func (ctx *Context) AddTask(request *AddTaskRequest) *Task {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 	return ctx.addTask(request)
 }
 
@@ -1148,9 +1089,7 @@ func (ctx *Context) RemoveTask(appID, taskID string) {
 }
 
 func (ctx *Context) getTask(appID string, taskID string) *Task {
-	ctx.lock.RLock()
-	defer ctx.lock.RUnlock()
-	app := ctx.getApplication(appID)
+	app := ctx.GetApplication(appID)
 	if app == nil {
 		log.Log(log.ShimContext).Debug("application is not found in the context",
 			zap.String("appID", appID))
@@ -1558,7 +1497,6 @@ func (ctx *Context) registerNodes(nodes []*v1.Node) ([]*v1.Node, error) {
 			},
 			SchedulableResource: common.GetNodeResource(&nodeStatus),
 			OccupiedResource:    common.NewResourceBuilder().Build(),
-			ExistingAllocations: make([]*si.Allocation, 0),
 		})
 		pendingNodes[node.Name] = node
 	}
@@ -1671,9 +1609,6 @@ func (ctx *Context) finalizeNodes(existingNodes []*v1.Node) error {
 	for _, node := range nodes {
 		nodeMap[node.Name] = node
 	}
-
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
 
 	// find any existing nodes that no longer exist
 	for _, node := range existingNodes {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1007,8 +1007,7 @@ func TestRecoverTask(t *testing.T) {
 	for _, tt := range taskInfoVerifiers {
 		t.Run(tt.taskID, func(t *testing.T) {
 			// verify the info for the recovered task
-			rt, err := app.GetTask(tt.taskID)
-			assert.NilError(t, err)
+			rt := app.GetTask(tt.taskID)
 			assert.Equal(t, rt.GetTaskState(), tt.expectedState)
 			assert.Equal(t, rt.allocationKey, tt.expectedAllocationKey)
 			assert.Equal(t, rt.pod.Name, tt.expectedPodName)
@@ -2142,9 +2141,8 @@ func TestTaskRemoveOnCompletion(t *testing.T) {
 
 	// check removal
 	app.Schedule()
-	appTask, err := app.GetTask(taskUID1)
+	appTask := app.GetTask(taskUID1)
 	assert.Assert(t, appTask == nil)
-	assert.Error(t, err, "task task00001 doesn't exist in application app01")
 }
 
 func TestAssumePod(t *testing.T) {

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -91,8 +91,8 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 			Name:      placeholderName,
 			Namespace: app.tags[constants.AppTagNamespace],
 			Labels: utils.MergeMaps(taskGroup.Labels, map[string]string{
-				constants.LabelApplicationID: app.GetApplicationID(),
-				constants.LabelQueueName:     app.GetQueue(),
+				constants.CanonicalLabelApplicationID: app.GetApplicationID(),
+				constants.CanonicalLabelQueueName:     app.GetQueue(),
 			}),
 			Annotations:     annotations,
 			OwnerReferences: ownerRefs,

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -85,6 +85,7 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 
 	// prepare the resource lists
 	requests := GetPlaceholderResourceRequests(taskGroup.MinResource)
+	var zeroSeconds int64 = 0
 	placeholderPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      placeholderName,
@@ -113,13 +114,14 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 					},
 				},
 			},
-			RestartPolicy:             constants.PlaceholderPodRestartPolicy,
-			SchedulerName:             constants.SchedulerName,
-			NodeSelector:              taskGroup.NodeSelector,
-			Tolerations:               taskGroup.Tolerations,
-			Affinity:                  taskGroup.Affinity,
-			TopologySpreadConstraints: taskGroup.TopologySpreadConstraints,
-			PriorityClassName:         priorityClassName,
+			RestartPolicy:                 constants.PlaceholderPodRestartPolicy,
+			SchedulerName:                 constants.SchedulerName,
+			NodeSelector:                  taskGroup.NodeSelector,
+			Tolerations:                   taskGroup.Tolerations,
+			Affinity:                      taskGroup.Affinity,
+			TopologySpreadConstraints:     taskGroup.TopologySpreadConstraints,
+			PriorityClassName:             priorityClassName,
+			TerminationGracePeriodSeconds: &zeroSeconds,
 		},
 	}
 

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -125,10 +125,10 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, holder.pod.Name, "ph-name")
 	assert.Equal(t, holder.pod.Namespace, namespace)
 	assert.DeepEqual(t, holder.pod.Labels, map[string]string{
-		constants.LabelApplicationID: appID,
-		constants.LabelQueueName:     queue,
-		"labelKey0":                  "labelKeyValue0",
-		"labelKey1":                  "labelKeyValue1",
+		constants.CanonicalLabelApplicationID: appID,
+		constants.CanonicalLabelQueueName:     queue,
+		"labelKey0":                           "labelKeyValue0",
+		"labelKey1":                           "labelKeyValue1",
 	})
 	assert.Equal(t, len(holder.pod.Annotations), 6, "unexpected number of annotations")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)

--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -158,7 +158,7 @@ func (callback *AsyncRMCallback) UpdateApplication(response *si.ApplicationRespo
 			zap.String("new status", updated.State))
 		switch updated.State {
 		case ApplicationStates().Completed:
-			callback.context.RemoveApplicationInternal(updated.ApplicationID)
+			callback.context.RemoveApplication(updated.ApplicationID)
 		case ApplicationStates().Resuming:
 			app := callback.context.GetApplication(updated.ApplicationID)
 			if app != nil && app.GetApplicationState() == ApplicationStates().Reserving {

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -85,7 +85,6 @@ func TestUpdateAllocation_NewTask_TaskNotFound(t *testing.T) {
 }
 
 func TestUpdateAllocation_NewTask_AssumePodFails(t *testing.T) {
-	t.Skip("disabled until YUNIKORN-2629 is resolved") // test can randomly trigger a deadlock, resulting in a failed build
 	callback, context := initCallbackTest(t, false, false)
 	defer dispatcher.UnregisterAllEventHandlers()
 	defer dispatcher.Stop()

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/looplab/fsm"
@@ -185,6 +186,22 @@ func (task *Task) UpdateTaskPodStatus(pod *v1.Pod) (*v1.Pod, error) {
 
 func (task *Task) UpdateTaskPod(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error) {
 	return task.context.apiProvider.GetAPIs().KubeClient.UpdatePod(pod, podMutator)
+}
+
+func (task *Task) failTaskPodWithReasonAndMsg(reason string, msg string) {
+	podCopy := task.pod.DeepCopy()
+	podCopy.Status = v1.PodStatus{
+		Phase:   v1.PodFailed,
+		Reason:  reason,
+		Message: msg,
+	}
+	log.Log(log.ShimCacheTask).Info("setting pod to failed", zap.String("podName", podCopy.Name))
+	pod, err := task.UpdateTaskPodStatus(podCopy)
+	if err != nil {
+		log.Log(log.ShimCacheTask).Error("failed to update task pod status", zap.Error(err))
+	} else {
+		log.Log(log.ShimCacheTask).Info("new pod status", zap.String("status", string(pod.Status.Phase)))
+	}
 }
 
 func (task *Task) isTerminated() bool {
@@ -457,16 +474,21 @@ func (task *Task) postTaskBound() {
 	}
 }
 
-func (task *Task) postTaskRejected() {
-	// currently, once task is rejected by scheduler, we directly move task to failed state.
-	// so this function simply triggers the state transition when it is rejected.
-	// but further, we can introduce retry mechanism if necessary.
+func (task *Task) postTaskRejected(reason string) {
+	// if task is rejected because of conflicting metadata, we should fail the pod with reason
+	if strings.Contains(reason, constants.TaskPodInconsistMetadataFailure) {
+		// Before version 1.7.0, this path would never be reached.
+		// After version 1.7.0, task pod should fail if pod has conflicting metadata.
+		task.failTaskPodWithReasonAndMsg(constants.TaskRejectedFailure, reason)
+	}
+
+	// move task to failed state.
 	dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID,
-		fmt.Sprintf("task %s failed because it is rejected by scheduler", task.alias)))
+		fmt.Sprintf("task %s failed because it is rejected", task.alias)))
 
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeWarning, "TaskRejected", "TaskRejected",
-		"Task %s is rejected by the scheduler", task.alias)
+		"Task %s is rejected", task.alias)
 }
 
 // beforeTaskFail releases the allocation or ask from scheduler core
@@ -543,7 +565,62 @@ func (task *Task) releaseAllocation() {
 // some sanity checks before sending task for scheduling,
 // this reduces the scheduling overhead by blocking such
 // request away from the core scheduler.
-func (task *Task) sanityCheckBeforeScheduling() error {
+func (task *Task) sanityCheckBeforeScheduling() (error, bool) {
+	rejectTask := false
+
+	if err := task.checkPodPVCs(); err != nil {
+		return err, rejectTask
+	}
+
+	// only check pod labels and annotations consistency if pod is not already bound
+	// reject the task if pod metadata is conflicting
+	if !utils.PodAlreadyBound(task.pod) {
+		if err := task.checkTaskPodWithoutConflictMetadata(); err != nil {
+			// Before version 1.7.0, return nil error and log a warning if pod metadata is conflicting
+			// After version 1.7.0, err should be returned if pod metadata is conflicting
+			// After version 1.7.0, rejectTask should be true if pod metadata is conflicting
+			log.Log(log.ShimCacheTask).Warn("Task pod has conflicting metadata, the unbound task pod will be rejected after version 1.7.0",
+				zap.String("appID", task.applicationID),
+				zap.String("podName", task.pod.Name),
+				zap.String("error", err.Error()))
+			return nil, rejectTask
+		}
+	}
+
+	return nil, rejectTask
+}
+
+func (task *Task) checkTaskPodWithoutConflictMetadata() error {
+	// check application ID
+	appIdLabelKeys := []string{
+		constants.CanonicalLabelApplicationID,
+		constants.SparkLabelAppID,
+		constants.LabelApplicationID,
+	}
+	appIdAnnotationKeys := []string{
+		constants.AnnotationApplicationID,
+	}
+	if !utils.ValidatePodLabelAnnotationConsistency(task.pod, appIdLabelKeys, appIdAnnotationKeys) {
+		return fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	}
+
+	// check queue name
+	queueLabelKeys := []string{
+		constants.CanonicalLabelQueueName,
+		constants.LabelQueueName,
+	}
+
+	queueAnnotationKeys := []string{
+		constants.AnnotationQueueName,
+	}
+
+	if !utils.ValidatePodLabelAnnotationConsistency(task.pod, queueLabelKeys, queueAnnotationKeys) {
+		return fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	}
+	return nil
+}
+
+func (task *Task) checkPodPVCs() error {
 	// Check PVCs used by the pod
 	namespace := task.pod.Namespace
 	manifest := &(task.pod.Spec)

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -624,8 +624,8 @@ func (task *Task) checkTaskPodWithoutConflictMetadata() error {
 }
 
 func (task *Task) checkPodPVCs() error {
-	task.lock.RLock()
 	// Check PVCs used by the pod
+	task.lock.RLock()
 	namespace := task.pod.Namespace
 	manifest := &(task.pod.Spec)
 	task.lock.RUnlock()

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -396,7 +396,15 @@ func callbacks(states *TStates) fsm.Callbacks {
 		},
 		states.Rejected: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
-			task.postTaskRejected()
+			eventArgs := make([]string, 1)
+			reason := ""
+			if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
+				log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
+				reason = err.Error()
+			} else {
+				reason = eventArgs[0]
+			}
+			task.postTaskRejected(reason)
 		},
 		states.Failed: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -784,7 +784,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			appIdInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in canonical label",
+			"have conflict queueName in canonical label",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queue2Name,
 				constants.LabelQueueName:          queueName,
@@ -794,7 +794,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			queueInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in legacy label",
+			"have conflict queueName in legacy label",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queueName,
 				constants.LabelQueueName:          queue2Name,
@@ -804,7 +804,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			queueInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in annotation",
+			"have conflict queueName in annotation",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queueName,
 				constants.LabelQueueName:          queueName,

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -702,6 +703,135 @@ func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {
 	err = task1.handle(ev1)
 	assert.NilError(t, err, "failed to handle AllocateTask event")
 	assert.Equal(t, task1.GetTaskState(), TaskStates().Completed)
+}
+
+// nolint: funlen
+func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
+	const (
+		appID      = "app01"
+		app2ID     = "app02"
+		queueName  = "root.sandbox1"
+		queue2Name = "root.sandbox2"
+	)
+	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+
+	testCases := []struct {
+		name           string
+		podLabels      map[string]string
+		podAnnotations map[string]string
+		expected       error
+	}{
+		{
+			"empty label and empty annotation in pod", nil, nil, nil,
+		},
+		{
+			"appId and queueName have no conflict",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApp:                    appID,
+				constants.CanonicalLabelQueueName:     queueName,
+				constants.LabelQueueName:              queueName,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+				constants.AnnotationQueueName:     queueName,
+			},
+			nil,
+		},
+		{
+			"have conflict appId in canonical label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: app2ID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in spark label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             app2ID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in legacy label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          app2ID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in annotation",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: app2ID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in canonical label",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queue2Name,
+				constants.LabelQueueName:          queueName,
+			}, map[string]string{
+				constants.AnnotationQueueName: queueName,
+			},
+			queueInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in legacy label",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queueName,
+				constants.LabelQueueName:          queue2Name,
+			}, map[string]string{
+				constants.AnnotationQueueName: queueName,
+			},
+			queueInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in annotation",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queueName,
+				constants.LabelQueueName:          queueName,
+			}, map[string]string{
+				constants.AnnotationQueueName: queue2Name,
+			},
+			queueInconsitentErr,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := NewApplication(appID, "root.default", "user", testGroups, map[string]string{}, nil)
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      tc.podLabels,
+					Annotations: tc.podAnnotations,
+				},
+			}
+			task := NewTask("task01", app, nil, pod)
+			err := task.checkTaskPodWithoutConflictMetadata()
+			if err != nil {
+				assert.Equal(t, tc.expected.Error(), err.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
 }
 
 func TestUpdatePodCondition(t *testing.T) {

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -713,8 +713,8 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 		queueName  = "root.sandbox1"
 		queue2Name = "root.sandbox2"
 	)
-	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
-	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistentMetadataFailure)
+	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistentMetadataFailure)
 
 	testCases := []struct {
 		name           string

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -19,7 +19,7 @@
 package client
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"go.uber.org/zap"
@@ -167,7 +167,7 @@ func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) error {
 
 	log.Log(log.ShimClient).Info("registering event handler", zap.Stringer("type", handlers.Type))
 	if err := s.addEventHandlers(handlers.Type, h, 0); err != nil {
-		return fmt.Errorf("failed to initialize event handlers: %w", err)
+		return errors.Join(errors.New("failed to initialize event handlers: "), err)
 	}
 	return nil
 }
@@ -200,7 +200,7 @@ func (s *APIFactory) addEventHandlers(
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to add event handlers: %w", err)
+		return errors.Join(errors.New("failed to add event handlers: "), err)
 	}
 	return nil
 }

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -86,6 +86,8 @@ var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft":
 
 const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"
+const TaskRejectedFailure = "TaskRejected"
+const TaskPodInconsistMetadataFailure = "PodInconsistentMetadata"
 
 // namespace.max.* (Retaining for backwards compatibility. Need to be removed in next major release)
 const CPUQuota = DomainYuniKorn + "namespace.max.cpu"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -87,7 +87,7 @@ var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft":
 const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"
 const TaskRejectedFailure = "TaskRejected"
-const TaskPodInconsistMetadataFailure = "PodInconsistentMetadata"
+const TaskPodInconsistentMetadataFailure = "PodInconsistentMetadata"
 
 // namespace.max.* (Retaining for backwards compatibility. Need to be removed in next major release)
 const CPUQuota = DomainYuniKorn + "namespace.max.cpu"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -99,6 +99,9 @@ const NamespaceQuota = DomainYuniKorn + "namespace.quota"
 // NamespaceGuaranteed Namespace Guaranteed
 const NamespaceGuaranteed = DomainYuniKorn + "namespace.guaranteed"
 
+// NamespaceMaxApps Namespace Max Apps
+const NamespaceMaxApps = DomainYuniKorn + "namespace.maxApps"
+
 // AnnotationAllowPreemption set on PriorityClass, opt out of preemption for pods with this priority class
 const AnnotationAllowPreemption = DomainYuniKorn + "allow-preemption"
 

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -510,6 +510,31 @@ func TestGetPodResourcesWithInPlacePodVerticalScaling(t *testing.T) {
 	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(4000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 	assert.Equal(t, res.Resources["pods"].GetValue(), int64(1))
+
+	// case: requested resource types are fewer than allocated types
+	containers = make([]v1.Container, 0)
+	c1Resources = make(map[v1.ResourceName]resource.Quantity)
+	containers = append(containers, v1.Container{
+		Name: "container-01",
+		Resources: v1.ResourceRequirements{
+			Requests: c1Resources,
+		},
+	})
+	pod.Spec.Containers = containers
+
+	c1Allocated[v1.ResourceMemory] = resource.MustParse("500M")
+	c1Allocated[v1.ResourceCPU] = resource.MustParse("2")
+	pod.Status.ContainerStatuses = []v1.ContainerStatus{
+		{AllocatedResources: c1Allocated},
+		{AllocatedResources: c2Allocated},
+	}
+	pod.Status.Resize = v1.PodResizeStatusProposed
+
+	res = GetPodResource(pod)
+	assert.Equal(t, res.Resources[siCommon.Memory].GetValue(), int64(500*1000*1000))
+	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(2000))
+	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(1))
+	assert.Equal(t, res.Resources["pods"].GetValue(), int64(1))
 }
 
 func TestBestEffortPod(t *testing.T) {
@@ -738,6 +763,122 @@ func TestParseResourceString(t *testing.T) {
 			memRes, hasMem := siResource.GetResources()[siCommon.Memory]
 			assert.Equal(t, hasMem, tc.memoryExist)
 			assert.Equal(t, memRes.GetValue(), tc.expectMemory)
+		})
+	}
+}
+
+func TestGetResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resMap      map[string]string
+		expectedRes map[string]int64
+	}{
+		{
+			name:        "empty resMap",
+			resMap:      map[string]string{},
+			expectedRes: map[string]int64{},
+		},
+		{
+			name: "single resource",
+			resMap: map[string]string{
+				v1.ResourceCPU.String(): "100m",
+			},
+			expectedRes: map[string]int64{
+				siCommon.CPU: 100,
+			},
+		},
+		{
+			name: "multiple resources",
+			resMap: map[string]string{
+				v1.ResourceCPU.String():    "1",
+				v1.ResourceMemory.String(): "1G",
+			},
+			expectedRes: map[string]int64{
+				siCommon.CPU:    1000,
+				siCommon.Memory: 1000 * 1000 * 1000,
+			},
+		},
+		{
+			name: "invalid cpu resources",
+			resMap: map[string]string{
+				v1.ResourceCPU.String(): "xyz",
+			},
+			expectedRes: nil,
+		},
+		{
+			name: "invalid memory resources",
+			resMap: map[string]string{
+				v1.ResourceMemory.String(): "64MiB",
+			},
+			expectedRes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualRes := GetResource(tt.resMap)
+			if tt.expectedRes == nil {
+				assert.Assert(t, actualRes == nil)
+			} else {
+				assert.Equal(t, len(actualRes.Resources), len(tt.expectedRes))
+				if len(tt.expectedRes) > 0 {
+					for name, value := range tt.expectedRes {
+						assert.Equal(t, actualRes.Resources[name].GetValue(), value)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetTGResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resMap      map[string]resource.Quantity
+		members     int64
+		expectedRes map[string]int64
+	}{
+		{
+			name:    "empty resMap",
+			resMap:  map[string]resource.Quantity{},
+			members: 2,
+			expectedRes: map[string]int64{
+				"pods": 2,
+			},
+		},
+		{
+			name: "single resource",
+			resMap: map[string]resource.Quantity{
+				v1.ResourceCPU.String(): resource.MustParse("100m"),
+			},
+			members: 2,
+			expectedRes: map[string]int64{
+				"pods":       2,
+				siCommon.CPU: 2 * 100,
+			},
+		},
+		{
+			name: "multiple resources",
+			resMap: map[string]resource.Quantity{
+				v1.ResourceCPU.String():    resource.MustParse("1"),
+				v1.ResourceMemory.String(): resource.MustParse("1G"),
+			},
+			members: 2,
+			expectedRes: map[string]int64{
+				"pods":          2,
+				siCommon.CPU:    2 * 1000,
+				siCommon.Memory: 2 * 1000 * 1000 * 1000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualRes := GetTGResource(tt.resMap, tt.members)
+			assert.Equal(t, len(actualRes.Resources), len(tt.expectedRes))
+			for name, value := range tt.expectedRes {
+				assert.Equal(t, actualRes.Resources[name].GetValue(), value)
+			}
 		})
 	}
 }

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -153,39 +153,6 @@ func CreateReleaseRequestForTask(appID, taskID, allocationKey, partition, termin
 	}
 }
 
-// CreateUpdateRequestForNewNode builds a NodeRequest for new node addition and restoring existing node
-func CreateUpdateRequestForNewNode(nodeID string, nodeLabels map[string]string, capacity *si.Resource, occupied *si.Resource,
-	existingAllocations []*si.Allocation) *si.NodeRequest {
-	// Use node's name as the NodeID, this is because when bind pod to node,
-	// name of node is required but uid is optional.
-	nodeInfo := &si.NodeInfo{
-		NodeID:              nodeID,
-		SchedulableResource: capacity,
-		OccupiedResource:    occupied,
-		Attributes: map[string]string{
-			constants.DefaultNodeAttributeHostNameKey: nodeID,
-			constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
-		},
-		ExistingAllocations: existingAllocations,
-		Action:              si.NodeInfo_CREATE,
-	}
-
-	// Add nodeLabels key value to Attributes map
-	for k, v := range nodeLabels {
-		nodeInfo.Attributes[k] = v
-	}
-
-	// Add instanceType to Attributes map
-	nodeInfo.Attributes[common.InstanceType] = nodeLabels[conf.GetSchedulerConf().InstanceTypeNodeLabelKey]
-
-	nodes := make([]*si.NodeInfo, 1)
-	nodes[0] = nodeInfo
-	return &si.NodeRequest{
-		Nodes: nodes,
-		RmID:  conf.GetSchedulerConf().ClusterID,
-	}
-}
-
 // CreateUpdateRequestForUpdatedNode builds a NodeRequest for capacity and occupied resource updates
 func CreateUpdateRequestForUpdatedNode(nodeID string, capacity *si.Resource, occupied *si.Resource) *si.NodeRequest {
 	nodeInfo := &si.NodeInfo{

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -45,6 +45,7 @@ func TestCreateReleaseRequestForTask(t *testing.T) {
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].ApplicationID, "app01")
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].AllocationKey, "task01")
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].PartitionName, "default")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].TerminationType, si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 
 	// without allocationKey
 	request = CreateReleaseRequestForTask("app01", "task01", "", "default", "STOPPED_BY_RM")
@@ -56,6 +57,21 @@ func TestCreateReleaseRequestForTask(t *testing.T) {
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].ApplicationID, "app01")
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].AllocationKey, "task01")
 	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].PartitionName, "default")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].TerminationType, si.TerminationType_UNKNOWN_TERMINATION_TYPE)
+
+	request = CreateReleaseRequestForTask("app01", "task01", "task01", "default", "UNKNOWN")
+	assert.Assert(t, request.Releases != nil)
+	assert.Assert(t, request.Releases.AllocationsToRelease != nil)
+	assert.Assert(t, request.Releases.AllocationAsksToRelease != nil)
+	assert.Equal(t, len(request.Releases.AllocationsToRelease), 1)
+	assert.Equal(t, len(request.Releases.AllocationAsksToRelease), 1)
+	assert.Equal(t, request.Releases.AllocationsToRelease[0].ApplicationID, "app01")
+	assert.Equal(t, request.Releases.AllocationsToRelease[0].AllocationKey, "task01")
+	assert.Equal(t, request.Releases.AllocationsToRelease[0].PartitionName, "default")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].ApplicationID, "app01")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].AllocationKey, "task01")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].PartitionName, "default")
+	assert.Equal(t, request.Releases.AllocationAsksToRelease[0].TerminationType, si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 }
 
 func TestCreateUpdateRequestForRemoveApplication(t *testing.T) {

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -228,33 +227,6 @@ func TestCreateTagsForTask(t *testing.T) {
 	pod.SetOwnerReferences(refer2)
 	result4 := CreateTagsForTask(pod)
 	assert.Equal(t, len(result4), 4)
-}
-
-func TestCreateUpdateRequestForNewNode(t *testing.T) {
-	capacity := NewResourceBuilder().AddResource(common.Memory, 200).AddResource(common.CPU, 2).Build()
-	occupied := NewResourceBuilder().AddResource(common.Memory, 50).AddResource(common.CPU, 1).Build()
-	var existingAllocations []*si.Allocation
-	nodeLabels := map[string]string{
-		"label1":                           "key1",
-		"label2":                           "key2",
-		"node.kubernetes.io/instance-type": "HighMem",
-	}
-	request := CreateUpdateRequestForNewNode(nodeID, nodeLabels, capacity, occupied, existingAllocations)
-	assert.Equal(t, len(request.Nodes), 1)
-	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
-	assert.Equal(t, request.Nodes[0].SchedulableResource, capacity)
-	assert.Equal(t, request.Nodes[0].OccupiedResource, occupied)
-	assert.Equal(t, len(request.Nodes[0].Attributes), 6)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeHostNameKey], nodeID)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeRackNameKey], constants.DefaultRackName)
-
-	// Make sure include nodeLabel
-	assert.Equal(t, request.Nodes[0].Attributes["label1"], "key1")
-	assert.Equal(t, request.Nodes[0].Attributes["label2"], "key2")
-	assert.Equal(t, request.Nodes[0].Attributes["node.kubernetes.io/instance-type"], "HighMem")
-
-	// Make sure include the instanceType
-	assert.Equal(t, request.Nodes[0].Attributes[common.InstanceType], "HighMem")
 }
 
 func TestCreateUpdateRequestForUpdatedNode(t *testing.T) {

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -268,6 +268,27 @@ func GetNamespaceGuaranteedFromAnnotation(namespaceObj *v1.Namespace) *si.Resour
 	return nil
 }
 
+// get namespace max apps from namespace annotation
+func GetNamespaceMaxAppsFromAnnotation(namespaceObj *v1.Namespace) string {
+	if maxApps := GetNameSpaceAnnotationValue(namespaceObj, constants.NamespaceMaxApps); maxApps != "" {
+		numMaxApp, err := strconv.Atoi(maxApps)
+		if err != nil {
+			log.Log(log.ShimUtils).Warn("Unable to process namespace.maxApps annotation",
+				zap.String("namespace", namespaceObj.Name),
+				zap.String("namespace.maxApps is", maxApps))
+			return ""
+		}
+		if numMaxApp < 0 {
+			log.Log(log.ShimUtils).Warn("Invalid value for namespace.maxApps annotation",
+				zap.String("namespace", namespaceObj.Name),
+				zap.String("namespace.maxApps is", maxApps))
+			return ""
+		}
+		return maxApps
+	}
+	return ""
+}
+
 func GetNamespaceQuotaFromAnnotation(namespaceObj *v1.Namespace) *si.Resource {
 	// retrieve resource quota info from annotations
 	cpuQuota := GetNameSpaceAnnotationValue(namespaceObj, constants.CPUQuota)

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -44,6 +45,10 @@ const userInfoKey = siCommon.DomainYuniKorn + "user.info"
 const uniqueAutogenSuffix = "-uniqueautogen"
 
 var pluginMode bool
+var (
+	// ErrorTimeout returned if waiting for a condition times out
+	ErrorTimeout = errors.New("timeout waiting for condition")
+)
 
 func SetPluginMode(value bool) {
 	pluginMode = value
@@ -250,7 +255,7 @@ func WaitForCondition(eval func() bool, interval time.Duration, timeout time.Dur
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for condition")
+			return ErrorTimeout
 		}
 
 		time.Sleep(interval)

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -331,6 +331,53 @@ func TestGetNamespaceGuaranteedFromAnnotation(t *testing.T) {
 	}
 }
 
+func TestGetNamespaceMaxAppsFromAnnotation(t *testing.T) {
+	testCases := []struct {
+		namespace      *v1.Namespace
+		expectedMaxApp string
+	}{
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		}, ""},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Annotations: map[string]string{
+					constants.NamespaceMaxApps: "5",
+				},
+			},
+		}, "5"},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Annotations: map[string]string{
+					constants.NamespaceMaxApps: "-5",
+				},
+			},
+		}, ""},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Annotations: map[string]string{
+					constants.NamespaceMaxApps: "error",
+				},
+			},
+		}, ""},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("namespace: %v", tc.namespace), func(t *testing.T) {
+			maxApp := GetNamespaceMaxAppsFromAnnotation(tc.namespace)
+			assert.Equal(t, maxApp, tc.expectedMaxApp)
+		})
+	}
+}
+
 func TestGetNamespaceQuotaFromAnnotationUsingNewAndOldAnnotations(t *testing.T) {
 	testCases := []struct {
 		namespace        *v1.Namespace

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,21 @@ func TestConvert2Pod(t *testing.T) {
 	pod, err = Convert2Pod(&v1.Pod{})
 	assert.NilError(t, err)
 	assert.Assert(t, pod != nil)
+}
+
+func TestConvert2ConfigMap(t *testing.T) {
+	configMap := &v1.ConfigMap{}
+	result := Convert2ConfigMap(configMap)
+	assert.Equal(t, result != nil, true)
+	assert.Equal(t, reflect.DeepEqual(result, configMap), true)
+
+	obj := struct{}{}
+	result = Convert2ConfigMap(obj)
+	assert.Equal(t, result == nil, true)
+
+	pod := &v1.Pod{}
+	result = Convert2ConfigMap(pod)
+	assert.Equal(t, result == nil, true)
 }
 
 func TestIsAssignedPod(t *testing.T) {
@@ -209,6 +225,15 @@ func TestGetNamespaceQuotaFromAnnotationUsingNewAnnotations(t *testing.T) {
 				Namespace: "test",
 				Annotations: map[string]string{
 					constants.DomainYuniKorn + "namespace.quota": "{\"cpu\": \"error\", \"memory\": \"error\"}",
+				},
+			},
+		}, nil},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Annotations: map[string]string{
+					constants.DomainYuniKorn + "namespace.quota": "expecting JSON object",
 				},
 			},
 		}, nil},
@@ -510,6 +535,7 @@ func TestPodUnderCondition(t *testing.T) {
 	assert.Equal(t, PodUnderCondition(pod, condition), false)
 }
 
+// nolint: funlen
 func TestGetApplicationIDFromPod(t *testing.T) {
 	defer SetPluginMode(false)
 	defer func() { conf.GetSchedulerConf().GenerateUniqueAppIds = false }()
@@ -624,9 +650,11 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			conf.GetSchedulerConf().GenerateUniqueAppIds = tc.generateUniqueAppIds
 			SetPluginMode(false)
+			assert.Equal(t, IsPluginMode(), false)
 			appID := GetApplicationIDFromPod(tc.pod)
 			assert.Equal(t, appID, tc.expectedAppID, "Wrong appID (standard mode)")
 			SetPluginMode(true)
+			assert.Equal(t, IsPluginMode(), true)
 			appID2 := GetApplicationIDFromPod(tc.pod)
 			assert.Equal(t, appID2, tc.expectedAppIDPluginMode, "Wrong appID (plugin mode)")
 		})
@@ -946,6 +974,22 @@ func TestPodAlreadyBound(t *testing.T) {
 	}
 }
 
+func TestIsPodRunning(t *testing.T) {
+	pod := &v1.Pod{
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	assert.Equal(t, IsPodRunning(pod), true)
+
+	pod = &v1.Pod{
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+		},
+	}
+	assert.Equal(t, IsPodRunning(pod), false)
+}
+
 func TestGetTaskGroupFromPodSpec(t *testing.T) {
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -1059,20 +1103,25 @@ func TestGetPlaceholderFlagFromPodSpec(t *testing.T) {
 	}
 }
 
-func TestGetCoreSchedulerConfigFromConfigMapNil(t *testing.T) {
-	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(nil))
-}
-
-func TestGetCoreSchedulerConfigFromConfigMapEmpty(t *testing.T) {
-	cm := map[string]string{}
-	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(cm))
-}
-
 func TestGetCoreSchedulerConfigFromConfigMap(t *testing.T) {
+	// case: mapping
 	cm := map[string]string{
 		"queues.yaml": "test",
 	}
 	assert.Equal(t, "test", GetCoreSchedulerConfigFromConfigMap(cm))
+
+	// case: not mapping
+	cm = map[string]string{
+		"unknow.yaml": "test",
+	}
+	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(cm))
+
+	// case: nil
+	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(nil))
+
+	// case: empty
+	cm = map[string]string{}
+	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(cm))
 }
 
 func TestGzipCompressedConfigMap(t *testing.T) {
@@ -1139,4 +1188,31 @@ func TestConvert2PriorityClass(t *testing.T) {
 	result := Convert2PriorityClass(&pc)
 	assert.Assert(t, result != nil)
 	assert.Equal(t, result.PreemptionPolicy, &preemptLower)
+}
+
+func TestWaitForCondition(t *testing.T) {
+	target := false
+	eval := func() bool {
+		return target
+	}
+	tests := []struct {
+		input    bool
+		interval time.Duration
+		timeout  time.Duration
+		output   error
+	}{
+		{true, time.Duration(1) * time.Second, time.Duration(2) * time.Second, nil},
+		{false, time.Duration(1) * time.Second, time.Duration(2) * time.Second, ErrorTimeout},
+		{true, time.Duration(3) * time.Second, time.Duration(2) * time.Second, nil},
+		{false, time.Duration(3) * time.Second, time.Duration(2) * time.Second, ErrorTimeout},
+	}
+	for _, test := range tests {
+		target = test.input
+		get := WaitForCondition(eval, test.timeout, test.interval)
+		if test.output == nil {
+			assert.NilError(t, get)
+		} else {
+			assert.Equal(t, get.Error(), test.output.Error())
+		}
+	}
 }

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -222,7 +222,7 @@ func (p *predicateManagerImpl) runPreFilterPlugins(ctx context.Context, state *f
 				zap.String("pluginName", plugin),
 				zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
 				zap.Error(err))
-			return framework.AsStatus(fmt.Errorf("running PreFilter plugin %q: %w", plugin, err)), plugin, skip
+			return framework.AsStatus(errors.Join(fmt.Errorf("running PreFilter plugin %q: ", plugin), err)), plugin, skip
 		}
 		// Merge is nil safe and returns a new PreFilterResult result if mergedNodes was nil
 		mergedNodes = mergedNodes.Merge(nodes)

--- a/pkg/plugin/scheduler_plugin.go
+++ b/pkg/plugin/scheduler_plugin.go
@@ -302,7 +302,7 @@ func NewSchedulerPlugin(_ context.Context, _ runtime.Object, handle framework.Ha
 
 func (sp *YuniKornSchedulerPlugin) getTask(appID, taskID string) (app *cache.Application, task *cache.Task, ok bool) {
 	if app := sp.context.GetApplication(appID); app != nil {
-		if task, err := app.GetTask(taskID); err == nil {
+		if task := app.GetTask(taskID); task != nil {
 			return app, task, true
 		}
 	}

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -160,7 +160,7 @@ func (ss *KubernetesShim) schedule() {
 	for _, app := range apps {
 		if app.GetApplicationState() == cache.ApplicationStates().Failed {
 			if app.AreAllTasksTerminated() {
-				ss.context.RemoveApplicationInternal(app.GetApplicationID())
+				ss.context.RemoveApplication(app.GetApplicationID())
 			}
 			continue
 		}

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -167,8 +167,7 @@ func (fc *MockScheduler) waitAndAssertTaskState(t *testing.T, appID, taskID, exp
 	assert.Equal(t, app != nil, true)
 	assert.Equal(t, app.GetApplicationID(), appID)
 
-	task, err := app.GetTask(taskID)
-	assert.NilError(t, err, "Task retrieval failed")
+	task := app.GetTask(taskID)
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		if task.GetTaskState() == expectedState {

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -17,9 +17,12 @@
 #limitations under the License.
 
 TOOLS_DIRECTORY=tools
-HELM=$TOOLS_DIRECTORY/helm
-KIND=$TOOLS_DIRECTORY/kind
-KUBECTL=$TOOLS_DIRECTORY/kubectl
+HELM_VERSION=$(make -s print_helm_version)
+KIND_VERSION=$(make -s print_kind_version)
+KUBECTL_VERSION=$(make -s print_kubectl_version)
+HELM=$TOOLS_DIRECTORY/helm-$HELM_VERSION/helm
+KIND=$TOOLS_DIRECTORY/kind-$KIND_VERSION/kind
+KUBECTL=$TOOLS_DIRECTORY/kubectl-$KUBECTL_VERSION/kubectl
 GO="${GO:-go}"
 export GO
 


### PR DESCRIPTION
### What is this PR for?

Support canonical Queue/ApplicationId labels in Pod, allows it coexist with the existing metadata.
- yunikorn.apache.org/app-id (New, **Canonical Label**)
- yunikorn.apache.org/queue (New, **Canonical Label)**

YuniKorn will reject those pod with conflicting metadata after version 1.7.0.
How:
- Check metadata consistency before move task state from 'New' to 'Pending'. Run the pod metadata check in task.sanityCheckBeforeScheduling()
- Before 1.7.0, If sanity check failed due to inconsistent metadata, then log a warning message
- After 1.7.0, If sanity check failed due to inconsistent metadata, move the task from 'New' to 'Rejected' state. And fail the pod with reasons.

ApplicationID is fetched from pod in below order:
1. Label: constants.CanonicalLabelApplicationID (**New**)
2. Annotation: constants.AnnotationApplicationID
3. Label: constants.LabelApplicationID
4. Label: constants.SparkLabelAppID

Queue name is fetched from pod in below ortder
1. Label: constants.CanonicalLabelQueueName (**New**)
2. Annotation: constants.AnnotationQueueName
3. Label: constants.LabelQueueName (**Previous:  constants.LabelQueueName  > constants.AnnotationQueueName**)
4. Default: constants.ApplicationDefaultQueue

### What type of PR is it?
* [X] - Feature

### Todos
- Admission Controller should fail the pod request too if the metadata is inconsistent. Will create another Jira once this PR got merged.
- Update Doc https://yunikorn.apache.org/docs/next/user_guide/labels_and_annotations_in_yunikorn

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2504


### How should this be tested?




Run below simple sleep pods:
```

apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-0001"
    yunikorn.apache.org/queue: "root.sandbox"
  annotations:
    yunikorn.apache.org/queue: "root.sandbox-another"
  name: pod-with-inconsistent-queue
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"
          


---
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-0002"
  annotations:
    yunikorn.apache.org/app-id: "application-sleep-0002-another"
  name: pod-with-inconsistent-app-id
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"
       
```

Check the shedule pod logs: 



### Screenshots (if appropriate)

### Questions:
NA
