### PR TITLE
[YUNIKORN-2504] Support canonical labels and align metadata retrievin order in shim

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -91,8 +91,8 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 			Name:      placeholderName,
 			Namespace: app.tags[constants.AppTagNamespace],
 			Labels: utils.MergeMaps(taskGroup.Labels, map[string]string{
-				constants.LabelApplicationID: app.GetApplicationID(),
-				constants.LabelQueueName:     app.GetQueue(),
+				constants.CanonicalLabelApplicationID: app.GetApplicationID(),
+				constants.CanonicalLabelQueueName:     app.GetQueue(),
 			}),
 			Annotations:     annotations,
 			OwnerReferences: ownerRefs,

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -125,10 +125,10 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, holder.pod.Name, "ph-name")
 	assert.Equal(t, holder.pod.Namespace, namespace)
 	assert.DeepEqual(t, holder.pod.Labels, map[string]string{
-		constants.LabelApplicationID: appID,
-		constants.LabelQueueName:     queue,
-		"labelKey0":                  "labelKeyValue0",
-		"labelKey1":                  "labelKeyValue1",
+		constants.CanonicalLabelApplicationID: appID,
+		constants.CanonicalLabelQueueName:     queue,
+		"labelKey0":                           "labelKeyValue0",
+		"labelKey1":                           "labelKeyValue1",
 	})
 	assert.Equal(t, len(holder.pod.Annotations), 6, "unexpected number of annotations")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)


### PR DESCRIPTION
### What is this PR for?

Support canonical Queue/ApplicationId labels in Pod, allows it coexist with the existing metadata.
- yunikorn.apache.org/app-id (New, **Canonical Label**)
- yunikorn.apache.org/queue (New, **Canonical Label)**

ApplicationID is fetched from pod in below order:
1. Label: constants.CanonicalLabelApplicationID (**New**)
2. Annotation: constants.AnnotationApplicationID
3. Label: constants.LabelApplicationID
4. Label: constants.SparkLabelAppID

Queue name is fetched from pod in below ortder
1. Label: constants.CanonicalLabelQueueName (**New**)
2. Annotation: constants.AnnotationQueueName
3. Label: constants.LabelQueueName (**Previous:  constants.LabelQueueName  > constants.AnnotationQueueName**)

### What type of PR is it?
* [X] - Feature

### Todos
- Throw warning if pod has conflicting metadata
- Update Doc https://yunikorn.apache.org/docs/next/user_guide/labels_and_annotations_in_yunikorn

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2504


### How should this be tested?
- Run the existing tests.
- Or create below pod:

```

apiVersion: v1
kind: ConfigMap
metadata:
  name: yunikorn-configs
  namespace: yunikorn
data:
  queues.yaml: |
    partitions:
      - name: default
        queues:
          - name: root
            submitacl: '*'
            queues:
              - name: sandbox
        placementrules:
          - name: provided
            create: true

---

apiVersion: v1
kind: Pod
metadata:
  labels:
    yunikorn.apache.org/app-id: "canonical-app-id"
    yunikorn.apache.org/queue: "root.sandbox"
  annotations:
    yunikorn.apache.org/app-id: "non-canonical-app-id"
    yunikorn.apache.org/queue: "root.sandbox-non-canonical"
  name: pod-with-canonical-metadata
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"
```

Check http://localhost:9889/ws/v1/partition/default/application/canonical-app-id:
- app-id = canonical-app-id
- queue = root.sandbox

### Screenshots (if appropriate)
<img width="742" alt="image" src="https://github.com/user-attachments/assets/13d95030-fadf-4dbe-9bd3-7d57da8e4fbf">

### Questions:
NA
